### PR TITLE
Fix a scroll issue on touch screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules/
 bundles
 *.ngsummary.json
 *.ngfactory.ts
+.idea
 lib
 dist

--- a/src/ngx-slimscroll/directives/slimscroll.directive.ts
+++ b/src/ngx-slimscroll/directives/slimscroll.directive.ts
@@ -229,7 +229,7 @@ export class SlimScrollDirective implements OnInit {
 
     const touchdrag = touchstart.mergeMap((e: TouchEvent) => {
       this.pageY = e.targetTouches[0].pageY;
-      this.top = parseFloat(getComputedStyle(bar).top);
+      this.top = -parseFloat(getComputedStyle(bar).top);
 
       return touchmove.map((tmove: TouchEvent) => {
         return -(this.top + tmove.targetTouches[0].pageY - this.pageY);
@@ -286,7 +286,7 @@ export class SlimScrollDirective implements OnInit {
   }
 
   @HostListener('window:resize', ['$event'])
-  onResize() {
+  onResize($event: any) {
     this.getBarHeight();
   }
 }


### PR DESCRIPTION
This commit is to fix a bug on touch screen devices (in my case it was iPad).

When you dragging screen to scroll the content, it works fine. But once you stop, and want to keep scrolling the following content, you will jump to the top of the content. This is actually because the _touchdrag_ function in _initDrag_ has a simple but fatal logic issue (I only changed one line code). So a easy fix but highly recommend to fix.

Also similar to #55 , I added an event parameter for the _onResize_ function to avoid the complain of AOT compiling.