### PR TITLE
build(dist): Build output module using CommonJS

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "es2015",
+    "module": "commonjs",
     "moduleResolution": "node",
     "target": "es5",
     "noImplicitAny": true,


### PR DESCRIPTION
Output module needs to be in a form so that it can be used with Angular Universal using `node`. `node` currently do not support `es2015` `import` and `export` statements.
