### PR TITLE
fix: perform setup by default if user don't specify it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,23 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-<a name="5.2.0"></a>
-# 5.2.0 (2018-07-16)
+<a name="5.2.1"></a>
+## [5.2.1](https://e-cloud.github.com/e-cloud/ngx-slimscroll/compare/v5.2.0...v5.2.1) (2018-07-16)
 
 
 ### Bug Fixes
 
-* replace the `bar-hidden` class with output event approach ([ad1b320](https://github.com/jkuri/ngx-slimscroll/commit/ad1b320))
-* undefined subscription for interactionSubscriptions ([c1a0ac9](https://github.com/jkuri/ngx-slimscroll/commit/c1a0ac9))
+* perform setup by default if user don't specify it ([d6854d6](https://e-cloud.github.com/e-cloud/ngx-slimscroll/commit/d6854d6))
 
 
-### Features
 
-* **renderer2:** update to Renderer2 ([95b1991](https://github.com/jkuri/ngx-slimscroll/commit/95b1991))
-* **sensitivity:** add scroll sensitivity option ([a3124e0](https://github.com/jkuri/ngx-slimscroll/commit/a3124e0))
-* add a class `bar-hidden` to wrapper to reveal the state ([1b8216a](https://github.com/jkuri/ngx-slimscroll/commit/1b8216a))
-* support enabled switch for the directive ([5fab880](https://github.com/jkuri/ngx-slimscroll/commit/5fab880))
+<a name="5.2.0"></a>
+# [5.2.0](https://e-cloud.github.com/e-cloud/ngx-slimscroll/compare/v5.1.0...v5.2.0) (2018-07-16)
+
+
+### Bug Fixes
+
+* undefined subscription for interactionSubscriptions ([c1a0ac9](https://e-cloud.github.com/e-cloud/ngx-slimscroll/commit/c1a0ac9))
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-slimscroll",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-slimscroll",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "license": "MIT",
   "main": "./dist/bundles/ngx-slimscroll.umd.js",
   "module": "./dist/ngx-slimscroll.es5.js",

--- a/src/app/ngx-slimscroll/directives/slimscroll.directive.ts
+++ b/src/app/ngx-slimscroll/directives/slimscroll.directive.ts
@@ -4,6 +4,7 @@ import {
   HostListener,
   OnChanges,
   OnDestroy,
+  OnInit,
   Renderer2,
   Inject,
   Optional,
@@ -39,7 +40,7 @@ export const easing: { [key: string]: Function } = {
   selector: '[slimScroll]', // tslint:disable-line
   exportAs: 'slimScroll'
 })
-export class SlimScrollDirective implements OnChanges, OnDestroy {
+export class SlimScrollDirective implements OnInit, OnChanges, OnDestroy {
   @Input() enabled = true;
   @Input() options: SlimScrollOptions;
   @Input() scrollEvents: EventEmitter<ISlimScrollEvent>;
@@ -69,6 +70,13 @@ export class SlimScrollDirective implements OnChanges, OnDestroy {
     this.el = viewContainer.element.nativeElement;
     this.body = this.document.querySelector('body');
     this.mutationThrottleTimeout = 50;
+  }
+
+  ngOnInit() {
+    // setup if no changes for enabled for the first time
+    if (!this.interactionSubscriptions && this.enabled) {
+      this.setup();
+    }
   }
 
   ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
@jkuri plz forgive me again 😓 . Another bug fixing.

Another thing. Here i revert the changes in changelog and run the release command. I know that you run it before. But i has some problem. Previously, you didn't create related tags for release commits. Therefore, it generate the wrong changelog. Please assign a git tag for my latest commit after merging or on your merged commit.

When you run git push after releasing, please append the flag `--follow-tags`, to push the tags to github.