### PR TITLE
Fix: Forwarding scroll events to scroll the full website when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import { NgSlimScrollModule, SLIMSCROLL_DEFAULTS } from 'ngx-slimscroll';
       provide: SLIMSCROLL_DEFAULTS,
       useValue: {
         alwaysVisible : false
-      }
+      } as ISlimScrollOptions
     },
   ],
   bootstrap: [ AppComponent ]
@@ -71,7 +71,7 @@ export class AppComponent implements OnInit {
   ngOnInit() {
     this.scrollEvents = new EventEmitter<SlimScrollEvent>();
     this.opts = {
-      position?: string; // left | right
+      position?: 'left' | 'right';
       barBackground?: string; // #C9C9C9
       barOpacity?: string; // 0.8
       barWidth?: string; // 10
@@ -85,6 +85,7 @@ export class AppComponent implements OnInit {
       alwaysVisible?: boolean; // true
       visibleTimeout?: number; // 1000
       scrollSensitivity?: number; // 1
+      alwaysPreventDefaultScroll?: boolean; // true
     }
 
     this.play();
@@ -163,7 +164,7 @@ There is an input of the directive `enabled` defaults to `true`. Some users may 
 
 ```ts
 export interface ISlimScrollOptions {
-  position?: string;
+  position?: 'left' | 'right';
   barBackground?: string;
   barOpacity?: string;
   barWidth?: string;
@@ -176,8 +177,24 @@ export interface ISlimScrollOptions {
   gridMargin?: string;
   alwaysVisible?: boolean;
   visibleTimeout?: number;
+  alwaysPreventDefaultScroll?: boolean;
 }
 ```
+**Description:**
+- `position`: The position of the scroll bar (default: `right`).
+- `barBackground`: The background color of the scroll bar (default: `#343a40`).
+- `barOpacity`: Defines the opacity of the scroll bar (default: `1`).
+- `barWidth`: Customize the width of the scroll bar (default: `12` px).
+- `barBorderRadius`: The border radius of the scroll bar (default: `5` px).
+- `barMargin`: The margin of the scroll bar. Supports the CSS-Style spelling (default: `1px 0`).
+- `gridBackground`: The background color of the grid (the line on which the scroll bar is arranged; default: `#adb5bd`).
+- `gridOpacity`: The opacity of the grid (default: `1`).
+- `gridWidth`: The width of the grid (default: `8` px).
+- `gridBorderRadius`: The border radius of the grid (default: `10` px).
+- `gridMargin`: The margin of the grid. Supports the CSS-Style spelling (default: `1px 2px`).
+- `alwaysVisible`: If this option is enabled the scroll bar is displayed permanently, otherwise it will be faded out after the visible timeout (default: `true`).
+- `visibleTimeout`: Represents the time the scroll bar is shown (default: `1000` ms). ***Hint**: It is necessary to set the option `alwaysVisible` to `false`*.
+- `alwaysPreventDefaultScroll`: Disable this flag to forward the scroll event if top or bottom of the slimscroll container is reached (default: `true`)
 
 ## Global Default Options
 
@@ -193,14 +210,15 @@ Example:
       provide: SLIMSCROLL_DEFAULTS,
       useValue: {
         alwaysVisible: false,
-        gridOpacity: '0.2', barOpacity: '0.5',
+        gridOpacity: '0.2', 
+        barOpacity: '0.5',
         gridBackground: '#c2c2c2',
         gridWidth: '6',
         gridMargin: '2px 2px',
         barBackground: '#2C3E50',
         barWidth: '6',
         barMargin: '2px 2px'
-      }
+      } as ISlimScrollOptions
     }
    // other providers
    ]

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,8 +1,6 @@
 import {
-  inject,
   async,
   fakeAsync,
-  tick,
   TestBed,
   ComponentFixture,
 } from '@angular/core/testing';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { NgSlimScrollModule } from '../ngx-slimscroll/src/module/ngx-slimscroll.module';
 
 import { AppComponent } from './app.component';
-import { SLIMSCROLL_DEFAULTS } from '../ngx-slimscroll/src/classes/slimscroll-options.class';
+import {ISlimScrollOptions, SLIMSCROLL_DEFAULTS} from '../ngx-slimscroll/src/classes/slimscroll-options.class';
 
 @NgModule({
   declarations: [
@@ -18,7 +18,7 @@ import { SLIMSCROLL_DEFAULTS } from '../ngx-slimscroll/src/classes/slimscroll-op
       provide: SLIMSCROLL_DEFAULTS,
       useValue: {
         alwaysVisible: false
-      }
+      } as ISlimScrollOptions
     },
   ],
   bootstrap: [AppComponent]

--- a/src/ngx-slimscroll/src/classes/slimscroll-options.class.ts
+++ b/src/ngx-slimscroll/src/classes/slimscroll-options.class.ts
@@ -14,6 +14,7 @@ export interface ISlimScrollOptions {
   gridMargin?: string;
   alwaysVisible?: boolean;
   visibleTimeout?: number;
+  alwaysPreventDefaultScroll?: boolean;
 }
 
 export const SLIMSCROLL_DEFAULTS: InjectionToken<ISlimScrollOptions>
@@ -33,6 +34,7 @@ export class SlimScrollOptions implements ISlimScrollOptions {
   gridMargin?: string;
   alwaysVisible?: boolean;
   visibleTimeout?: number;
+  alwaysPreventDefaultScroll?: boolean;
 
   constructor(obj?: ISlimScrollOptions) {
     this.position = obj && obj.position ? obj.position : 'right';
@@ -48,6 +50,7 @@ export class SlimScrollOptions implements ISlimScrollOptions {
     this.gridMargin = obj && obj.gridMargin ? obj.gridMargin : '1px 2px';
     this.alwaysVisible = obj && typeof obj.alwaysVisible !== 'undefined' ? obj.alwaysVisible : true;
     this.visibleTimeout = obj && obj.visibleTimeout ? obj.visibleTimeout : 1000;
+    this.alwaysPreventDefaultScroll = obj && typeof obj.alwaysPreventDefaultScroll !== 'undefined' ? obj.alwaysPreventDefaultScroll : true;
   }
 
   public merge(obj?: ISlimScrollOptions): SlimScrollOptions {
@@ -66,6 +69,7 @@ export class SlimScrollOptions implements ISlimScrollOptions {
     result.gridMargin = obj && obj.gridMargin ? obj.gridMargin : this.gridMargin;
     result.alwaysVisible = obj && typeof obj.alwaysVisible !== 'undefined' ? obj.alwaysVisible : this.alwaysVisible;
     result.visibleTimeout = obj && obj.visibleTimeout ? obj.visibleTimeout : this.visibleTimeout;
+    result.alwaysPreventDefaultScroll = obj && typeof obj.alwaysPreventDefaultScroll !== 'undefined' ? obj.alwaysPreventDefaultScroll : true;
 
     return result;
   }

--- a/src/ngx-slimscroll/src/classes/slimscroll-options.class.ts
+++ b/src/ngx-slimscroll/src/classes/slimscroll-options.class.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from '@angular/core';
 
 export interface ISlimScrollOptions {
-  position?: string;
+  position?: 'left' | 'right';
   barBackground?: string;
   barOpacity?: string;
   barWidth?: string;
@@ -21,7 +21,7 @@ export const SLIMSCROLL_DEFAULTS: InjectionToken<ISlimScrollOptions>
     = new InjectionToken('NGX_SLIMSCROLL_DEFAULTS');
 
 export class SlimScrollOptions implements ISlimScrollOptions {
-  position?: string;
+  position?: 'left' | 'right';
   barBackground?: string;
   barOpacity?: string;
   barWidth?: string;

--- a/src/ngx-slimscroll/src/directives/slimscroll.directive.ts
+++ b/src/ngx-slimscroll/src/directives/slimscroll.directive.ts
@@ -330,9 +330,9 @@ export class SlimScrollDirective implements OnInit, OnChanges, OnDestroy {
         delta = e.detail / 3;
       }
 
-      this.scrollContent(delta, true, false);
+      const over = this.scrollContent(delta, true, false);
 
-      if (e.preventDefault) {
+      if (e.preventDefault && (this.options.alwaysPreventDefaultScroll || over === null)) {
         e.preventDefault();
       }
     });


### PR DESCRIPTION
This pull request is a fix for issue #119. 

Now, it is possible to scroll the full page even if the mouse is hovered above the slimscroll container but the top or the buttom of the slimscroll container is reached while scrolling. To prevent a breaking change the current behaviour is the "normal" one. But it is possible by an option to deactivate the preventing of the scroll events .

**The following changes were made:**

- it is possible to scroll the full website when there is a browser specific scroll bar and the top or the buttom of the sclimscroll container is reached while scrolling
- added an option to de-/activate this new behaviour
- the possible values of the position option were reduced to 'left' and 'right'
- the Readme.md was updated and a description block for the options was added