### PR TITLE
Update package.json to include the repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,10 @@
         "webpack-cli": "^4.7.2"
       }
     },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/jkuri/ngx-slimscroll.git"
+    },
     "node_modules/@angular-devkit/architect": {
       "version": "0.1201.0",
       "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1201.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "e2e": "ng e2e",
     "changelog": "standard-changelog --save standard-changelog"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jkuri/ngx-slimscroll.git"
+  },
   "private": true,
   "dependencies": {
     "@angular/animations": "~12.1.0",

--- a/projects/ngx-slimscroll/package.json
+++ b/projects/ngx-slimscroll/package.json
@@ -5,6 +5,11 @@
     "@angular/common": ">= 12.0.0",
     "@angular/core": ">= 12.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jkuri/ngx-slimscroll.git",
+    "directory": "projects/ngx-slimscroll"
+  },
   "dependencies": {
     "tslib": "^2.2.0"
   }


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• ngx-slimscroll
• slimscroll